### PR TITLE
use apt update to avoid raspberry pi stable vs oldstable failure

### DIFF
--- a/rpms-build/release/etc/cron.daily/update-lomod
+++ b/rpms-build/release/etc/cron.daily/update-lomod
@@ -3,5 +3,5 @@ set -xe
 
 admintoken=$(cat /opt/lomorage/etc/admin.json | jq -r '."admin-token"')
 curl -s "127.0.0.1:8000/user?token=$admintoken" | jq -r .Users[].HomeDir | sudo xargs -I {} cp /opt/lomorage/var/assets.db {}
-sudo apt-get update
+sudo apt update -y
 sudo -u pi sudo apt-get --only-upgrade install -y lomo-base lomo-base-lite lomo-vips lomo-backend lomo-web lomo-frame


### PR DESCRIPTION
https://raspberrypi.stackexchange.com/questions/130924/update-problem-with-apt-get-after-new-install-of-os

Signed-off-by: Deweb Fan <dwebfan@gmail.com>